### PR TITLE
Debug level 3

### DIFF
--- a/Assets/PopSignMain/Scripts/Bubbles/ball.cs
+++ b/Assets/PopSignMain/Scripts/Bubbles/ball.cs
@@ -279,8 +279,19 @@ public class ball : MonoBehaviour
             float distanceToBall = Vector3.Distance(transform.position, obj.transform.position);
             if (distanceToBall <= 0.9f && distanceToBall > 0)
             {
-                ballsToClear.Add(obj);
-                obj.GetComponent<bouncer>().checkNextNearestColor(ballsToClear);
+                bool notIn = true;
+                foreach (GameObject ball in ballsToClear)
+                {
+                    if (ball == obj)
+                    {
+                        notIn = false;
+                    }
+                }
+                if (notIn)
+                {
+                    ballsToClear.Add(obj);
+                    obj.GetComponent<bouncer>().checkNextNearestColor(ballsToClear);
+                }
             }
         }
 

--- a/Assets/PopSignMain/Scripts/Bubbles/creatorBall.cs
+++ b/Assets/PopSignMain/Scripts/Bubbles/creatorBall.cs
@@ -413,9 +413,6 @@ public GameObject createBall( Vector3 vec, BallColor color = BallColor.random, b
     else
     {
         b.GetComponent<ball>().enabled = false;
-        if (PlayerPrefs.GetInt("OpenLevel") == 3 && row == 11){
-            b.GetComponent<ball>().isTarget = true;
-        }
         if( LevelData.mode == ModeGame.Vertical && row == 0 )
             b.GetComponent<ball>().isTarget = true;
         b.GetComponent<BoxCollider2D>().offset = Vector2.zero;

--- a/Assets/PopSignMain/Scripts/Core/mainscript.cs
+++ b/Assets/PopSignMain/Scripts/Core/mainscript.cs
@@ -296,6 +296,10 @@ void Update ()
     {
         MustPopCount = 1;
     }
+    else if (LevelData.mode == ModeGame.Vertical)
+    {
+            MustPopCount = 11;
+    }
     else
     {
         MustPopCount = 11;
@@ -443,10 +447,14 @@ public IEnumerator clearDisconnectedBalls()
                     if(b.Count >0 && BallWhiffed == false)
                     {
                         willDestroy++;
-                        if (PlayerPrefs.GetInt("OpenLevel") == 3 || PlayerPrefs.GetInt("OpenLevel") == 6 ||
+                        if ((PlayerPrefs.GetInt("OpenLevel") == 3 || PlayerPrefs.GetInt("OpenLevel") == 6 ||
                             PlayerPrefs.GetInt("OpenLevel") == 7 || PlayerPrefs.GetInt("OpenLevel") == 8 ||
                             PlayerPrefs.GetInt("OpenLevel") == 10 || PlayerPrefs.GetInt("OpenLevel") == 11 ||
-                            PlayerPrefs.GetInt("OpenLevel") == 12 || PlayerPrefs.GetInt("OpenLevel") == 14 || PlayerPrefs.GetInt("OpenLevel") == 16 || PlayerPrefs.GetInt("OpenLevel") == 17 ||  PlayerPrefs.GetInt("OpenLevel") == 18 ||  PlayerPrefs.GetInt("OpenLevel") == 19 ||  PlayerPrefs.GetInt("OpenLevel") == 21 ||  PlayerPrefs.GetInt("OpenLevel") == 23)
+                            PlayerPrefs.GetInt("OpenLevel") == 12 || PlayerPrefs.GetInt("OpenLevel") == 14 || 
+                            PlayerPrefs.GetInt("OpenLevel") == 16 || PlayerPrefs.GetInt("OpenLevel") == 17 ||  
+                            PlayerPrefs.GetInt("OpenLevel") == 18 ||  PlayerPrefs.GetInt("OpenLevel") == 19 ||  
+                            PlayerPrefs.GetInt("OpenLevel") == 21 ||  PlayerPrefs.GetInt("OpenLevel") == 23) &&
+                            (LevelData.mode != ModeGame.Vertical))
                         {
                             TargetCounter++;
                         }
@@ -583,8 +591,17 @@ public void destroy( ArrayList b)
     Camera.main.GetComponent<mainscript>().bounceCounter = 0;
     int scoreCounter = 0;
     int rate = 0;
-
+    bool hasTarget = false;
     foreach(GameObject obj in b) {
+        if (obj.GetComponent<ball>().isTarget)
+            hasTarget = true;
+    }
+    if (hasTarget)
+    {
+        return;
+    }
+
+    foreach (GameObject obj in b) {
         // if(obj.name.IndexOf("ball")==0) obj.layer = 0;
         if(!obj.GetComponent<ball>().Destroyed) {
             if(scoreCounter > 3) {

--- a/Assets/PopSignMain/Scripts/Editor/InactiveCodeDetector.cs.meta
+++ b/Assets/PopSignMain/Scripts/Editor/InactiveCodeDetector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9ffff87af57bd48d5805ba282d51be6d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The bugs in level 3 contain two parts:
1. Unproper check box showing on line 11 counting from the top
2. The bubble destroying function does not check duplication while destroying.

### First Part
In the "creatorBall.cs" file, there were several lines adding checkmarks to line 11. 
Adding or removing checkmarks is done by the initialization functions by setting the `isTarget` field of `Ball` object. If that field is set to `true`, then the corresponding Ball becomes a checkmark on exploding.
The definition of `Ball` object can be found in file "ball.cs" from line 4 to line 929.
The initialization function can be found in file "creatorBall.cs" from line 367 to line 438.

### Second Part
This issue is quite complex.
Level 3 is a "Vertical" level, in which the pass scenario is defined by clearing all the bubbles on the top row. However, in the code files, this is converted to check how many `Ball` objects with `isTarget` set as `true` are destroyed. The logic is the following:

Step 1: a) clear all the bubbles on the top row is passing; b) the top row has fixed number of bubbles; => destroy a fixed number of bubbles on the top row is passing
Step 2: a) destroy a fixed number of bubbles on the top row is passing; b) only and only if a bubble is on the top row, the bubble should be set `isTarget` as true; => destroy a fixed number of bubbles with`isTarget` set as true is passing
Step 3: a) destroy a fixed number of bubbles with`isTarget` set as true is passing; b) one bubble can only be destroyed once; => perform a fixed number of destroy on the bubbles with `isTarget` set as true is passing

Accordingly, the program only checks how many times a specific type of destroying is performed. However, there were several problems.

Problem 1: As the first part explained, level 3 has some additional bubbles with `isTarget` set as `true`, therefore, the number is mismatched.
Problem 2: In the destroying function, the bubble that is directly hit by the shooting would invoke the specific destroying function twice. The first called function collects all the bubbles that should be destroyed in an array, but it does not check duplications in the array. The second called function, the specific destroying function simply destroys all the elements in the array made by the first called function.

In a conclusion, the bug of clearing level 3 too early is caused by the unmatching between the checked number and the threshold. Moreover, a similar problem existed in level 6, and all the similar problems should be solved in this commit.