### PR TITLE
reverted randomized levels to original (new words every level rather …

### DIFF
--- a/Assets/PopSignMain/RandomizeLevel/EnableRandomLevels.cs
+++ b/Assets/PopSignMain/RandomizeLevel/EnableRandomLevels.cs
@@ -70,7 +70,7 @@ public class EnableRandomLevels : MonoBehaviour
 		{
 			
 			string[] selectedWords = new string[5];
-			/*
+			
 			for (int i = 0; i < selectedWords.Length; i++)
 			{
 				int randomNumber = Random.Range(0, wordList.Length);
@@ -86,8 +86,9 @@ public class EnableRandomLevels : MonoBehaviour
 				}
 				selectedWords[i] = wordSelected;
 			}
-			*/
 			
+			
+			/* 
 			for(int i = 0; i < selectedWords.Length; i++)
 			{
 				int wordIndex = (((level - 1) / 5)*5) + i;
@@ -97,7 +98,7 @@ public class EnableRandomLevels : MonoBehaviour
 				}
 				selectedWords[i] = wordList[wordIndex].Trim();
 			}
-			
+			*/
 			StringBuilder sb = new StringBuilder();
 			JsonWriter writer = new JsonWriter(sb);
 

--- a/Assets/PopSignMain/Scripts/Core/AnimationManager.cs
+++ b/Assets/PopSignMain/Scripts/Core/AnimationManager.cs
@@ -166,7 +166,12 @@ public class AnimationManager : MonoBehaviour
             {
                 PlayerPrefs.SetInt("OpenLevel", PlayerPrefs.GetInt("OpenLevel") + 1);
                 PlayerPrefs.Save();
-                if (PlayerPrefs.GetInt("OpenLevel") % PRACTICE_LEVEL_INTERVAL == 0) {
+
+                int randomizeLevels = PlayerPrefs.GetInt("RandomizeLevel", 0); //Added for randomized levels
+
+                //Added or statement to check if randomizedLevels = 1 to see if practice should be shown before every level
+                if (PlayerPrefs.GetInt("OpenLevel") % PRACTICE_LEVEL_INTERVAL == 0 || randomizeLevels == 1) {
+                    VideoManager.resetVideoManager(); //Added to fix bug where words from previous level were shown in practice video rather than current level
                     SceneManager.LoadScene("practice");
                 } else {
                     SceneManager.LoadScene("game");


### PR DESCRIPTION
…than every 5 levels), practice videos now appear before every level when randomized levels enabled, fixed bug with pratice videos displaying the words for the previous levels rather than the current levels