### PR TITLE
Fix progress bar

### DIFF
--- a/Assets/PopSignMain/Scripts/Core/mainscript.cs
+++ b/Assets/PopSignMain/Scripts/Core/mainscript.cs
@@ -309,7 +309,8 @@ void Update ()
         //    GamePlay.Instance.GameStatus = GameState.GameOver;
 
         // ProgressBarScript.Instance.UpdateDisplay( (float)score * 100f / ( (float)LevelData.star1 / ( ( LevelData.star1 * 100f / LevelData.star3 ) ) * 100f ) /100f );
-        ProgressBarScript.Instance.UpdateDisplay( (float)score * 100f / ( (float)1000 / ( ( 1000 * 100f / 2000 ) ) * 100f ) / 100f );
+        // ProgressBarScript.Instance.UpdateDisplay( (float)score * 100f / ( (float)1000 / ( ( 1000 * 100f / 2000 ) ) * 100f ) / 100f );
+        ProgressBarScript.Instance.UpdateDisplay((float) score / (float) LevelData.star3);
 
 
     // update the number of stars the player has received


### PR DESCRIPTION
The old progress bar was inaccurate because it assumed that the max score was 2000 (previous hardcoded value). Updated the progress bar so that it uses the actual max score value, which is different for each level. However, the progress bar is still not completely accurate for levels that have the big star in the middle where you have to pop all bubbles to win.